### PR TITLE
Handle request options from parsed url

### DIFF
--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.test.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.test.ts
@@ -1,5 +1,5 @@
 import { parse } from 'url'
-import { Agent as HttpsAgent, RequestOptions } from 'https'
+import { Agent as HttpsAgent } from 'https'
 import { getUrlByRequestOptions } from '../../../utils/getUrlByRequestOptions'
 import { normalizeClientRequestArgs } from './normalizeClientRequestArgs'
 

--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.test.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.test.ts
@@ -1,5 +1,5 @@
 import { parse } from 'url'
-import { Agent as HttpsAgent } from 'https'
+import { Agent as HttpsAgent, RequestOptions } from 'https'
 import { getUrlByRequestOptions } from '../../../utils/getUrlByRequestOptions'
 import { normalizeClientRequestArgs } from './normalizeClientRequestArgs'
 
@@ -234,6 +234,27 @@ test('handles [RequestOptions, callback] input', () => {
 
   // Request options must be preserved.
   expect(options).toEqual(initialOptions)
+
+  // Callback must be preserved.
+  expect(callback?.name).toEqual('cb')
+})
+
+// example of this pattern being used
+// https://github.com/EventSource/eventsource/blob/master/lib/eventsource.js#L84-L139
+test('handles [RequestOptions, callback] input when creating input options with url.parse', () => {
+  const initialOptions = {...parse('https://mswjs.io/resource'), headers: {'Content-Type': 'text/plain'}}
+
+  const [url, options, callback] = normalizeClientRequestArgs(
+    'https:',
+    initialOptions,
+    function cb() {}
+  )
+
+  // URL must be derived from request options.
+  expect(url.href).toEqual('https://mswjs.io/resource')
+
+  // Request headers must be preserved
+  expect(options.headers).toEqual(initialOptions.headers)
 
   // Callback must be preserved.
   expect(callback?.name).toEqual('cb')

--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
@@ -111,7 +111,7 @@ export function normalizeClientRequestArgs(
   }
   // Handle a legacy URL instance and re-normalize from either a RequestOptions object
   // or a WHATWG URL.
-  else if ('hash' in args[0] && !('method' in args[0]) && !('headers' in args[0])) {
+  else if ('hash' in args[0] && !('method' in args[0])) {
     const [legacyUrl] = args
     log('first argument is a legacy URL:', legacyUrl)
 

--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
@@ -111,7 +111,7 @@ export function normalizeClientRequestArgs(
   }
   // Handle a legacy URL instance and re-normalize from either a RequestOptions object
   // or a WHATWG URL.
-  else if ('hash' in args[0] && !('method' in args[0])) {
+  else if ('hash' in args[0] && !('method' in args[0]) && !('headers' in args[0])) {
     const [legacyUrl] = args
     log('first argument is a legacy URL:', legacyUrl)
 

--- a/test/modules/http/intercept/https.request.test.ts
+++ b/test/modules/http/intercept/https.request.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 import * as https from 'https'
+import { parse } from 'url'
 import { RequestHandler } from 'express'
 import { ServerApi, createServer, httpsAgent } from '@open-draft/test-server'
 import { createInterceptor } from '../../../../src'
@@ -235,4 +236,12 @@ test('sets "credentials" to "omit" on the isomorphic request', (done) => {
       const [request] = requests
       expect(request.credentials).toEqual('omit')
     })
+})
+
+test('keeps headers when RequestOptions is created from url.parse', (done) => {
+  const requestOptions = {...parse('https://mswjs.io/resource'), headers: {'authorization': 'auth-token'}}
+  https.request(requestOptions, () => done()).end(() => {
+    const [request] = requests
+    expect(request.headers.get('authorization')).toEqual(requestOptions.headers.authorization)
+  })
 })


### PR DESCRIPTION
# Motivation
Some node libraries (notably the eventsource library) use the `url.parse` method to generate a RequestOption payload to pass to `https.request`. When this happens the interceptor strips any provided headers (and possibly other configuration) from the request.
Here is an example repo of this behavior causing the launch darkly client to fail when mock service worker is running:
https://github.com/dg-harris/ld-msw-authentication-issue

# Change description
The test addition is the main value here as a demonstration of the issue. 
The actual edit to normalizeClientRequestArgs is very likely not the the correct change, it's more to highlight the section of code where the issue is occurring. 